### PR TITLE
Python 3 compat, don't ignore credential_file arg, don't crash on 1st msg when chat was empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ run.bat
 __pycache__/
 *.py[cod]
 
+# vim swp files
+.*.swp
+
+# Secrets
+oauth_creds
+client_secrets.json
+
 # C extensions
 *.so
 

--- a/example.py
+++ b/example.py
@@ -9,7 +9,7 @@ chat_obj = YoutubeLiveChat("oauth_creds", [livechat_id])
 
 def respond(msgs, chatid):
     for msg in msgs:
-        print msg
+        print(msg)
         msg.delete()
         chat_obj.send_message("RESPONSE!", chatid)
 
@@ -17,8 +17,7 @@ def respond(msgs, chatid):
 try:
     chat_obj.start()
     chat_obj.subscribe_chat_message(respond)
-    while True:
-        sleep(0.1)
+    chat_obj.join()
 
 finally:
     chat_obj.stop()

--- a/get_oauth_token.py
+++ b/get_oauth_token.py
@@ -1,14 +1,18 @@
+#!/usr/bin/env python
 from oauth2client import client
 from oauth2client.file import Storage
 import webbrowser
 import httplib2
+if not hasattr(__builtins__,'raw_input'):
+    # Python 3
+    raw_input = input
 flow = client.flow_from_clientsecrets(
     'client_secrets.json',
     scope=['https://www.googleapis.com/auth/youtube', 'https://www.googleapis.com/auth/youtube.force-ssl'],
     redirect_uri='urn:ietf:wg:oauth:2.0:oob')
 auth_uri = flow.step1_get_authorize_url()
 webbrowser.open(auth_uri)
-auth_code = raw_input("auth code :")
+auth_code = raw_input("auth code: ")
 credentials = flow.step2_exchange(auth_code)
 http_auth = credentials.authorize(httplib2.Http())
 storage = Storage("oauth_creds")

--- a/youtubechat/__init__.py
+++ b/youtubechat/__init__.py
@@ -1,1 +1,1 @@
-from ytchat import *
+from .ytchat import *


### PR DESCRIPTION
- Python 3 compatibility:
  - `raw_input` -> `input`
  - decode `bytes` read from network with correct charset
  - `HTMLParser` -> `html`
  - `urllib.urlopen` -> `urllib.parse.urlopen`
  - new `except` syntax
  - relative imports
- In several function the `credential_file` parameter was ignored and a hard coded string was used instead.
- In case the chat was empty when the example script was started the script crashed when the first message arrived.
- Handle API errors in `_json_request`.
- git ignore vim .swp files and secret files.
